### PR TITLE
Updated urllib3 to secure version and fixed dependabot finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ The new architecture follows software engineering best practices:
 - **Better command line interface**: Added proper argument parsing with help messages
 
 #### **🍎 macOS Compatibility**
-- **Fixed urllib3 LibreSSL warning**: Pinned urllib3 to v1.x for macOS compatibility
+- **Updated urllib3**: Upgraded to v2.5.0+ for SSRF security fix (LibreSSL warning on macOS is non-critical)
 - **Resolved SSL warnings**: Clean output without OpenSSL compatibility warnings
 
 #### **Technical Improvements**

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pydantic>=2.0.0
 pathlib
 python-dotenv>=1.0.0
 requests>=2.28.0
-urllib3<2.0
+urllib3>=2.5.0  # Security fix for SSRF vulnerability
 rich>=13.0.0
 defusedxml>=0.7.1  # Secure XML parsing
 


### PR DESCRIPTION
urllib3 handles redirects and retries using the same mechanism, which is controlled by the Retry object. The most common way to disable redirects is at the request level, as follows:

resp = urllib3.request("GET", "https://httpbin.org/redirect/1", redirect=False)
print(resp.status)
# 302
However, it is also possible to disable redirects, for all requests, by instantiating a PoolManager and specifying retries in a way that disable redirects:

import urllib3

http = urllib3.PoolManager(retries=0)  # should raise MaxRetryError on redirect
http = urllib3.PoolManager(retries=urllib3.Retry(redirect=0))  # equivalent to the above
http = urllib3.PoolManager(retries=False)  # should return the first response

resp = http.request("GET", "https://httpbin.org/redirect/1")
However, the retries parameter is currently ignored, which means all the above examples don't disable redirects.